### PR TITLE
Use proper DBus types for numbers

### DIFF
--- a/lvmdbus.py
+++ b/lvmdbus.py
@@ -27,7 +27,7 @@ import signal
 import sys
 import cmdhandler
 import utils
-from utils import n
+from utils import n, n32
 import time
 
 # Shared state variable across all processes
@@ -601,7 +601,7 @@ class Vg(utils.AutomatedProperties):
 @utils.dbus_property('size_bytes', 's')
 @utils.dbus_property('pool_lv', 'o')
 @utils.dbus_property('origin_lv', 'o')
-@utils.dbus_property('data_percent', 'i')
+@utils.dbus_property('data_percent', 'u')
 class Lv(utils.AutomatedProperties):
     DBUS_INTERFACE = LV_INTERFACE
     _tags_type = "as"
@@ -771,7 +771,7 @@ class Lv(utils.AutomatedProperties):
 @utils.dbus_property('size_bytes', 's')
 @utils.dbus_property('pool_lv', 'o')
 @utils.dbus_property('origin_lv', 'o')
-@utils.dbus_property('data_percent', 'i')
+@utils.dbus_property('data_percent', 'u')
 class LvPool(utils.AutomatedProperties):
     _tags_type = "as"
     _vg_type = "o"
@@ -900,14 +900,14 @@ def load_lvs(connection, obj_manager, lv_name=None):
                     l['lv_uuid'],
                     l['lv_name'], l['lv_path'], n(l['lv_size']),
                     l['vg_name'], l['pool_lv'], l['origin'],
-                    n(l['data_percent']), l['lv_attr'], l['lv_tags'])
+                    n32(l['data_percent']), l['lv_attr'], l['lv_tags'])
         else:
             lv = LvPool(connection, thin_pool_path(l['lv_name']),
                         obj_manager,
                         l['lv_uuid'],
                         l['lv_name'], l['lv_path'], n(l['lv_size']),
                         l['vg_name'], l['pool_lv'], l['origin'],
-                        n(l['data_percent']), l['lv_attr'], l['lv_tags'])
+                        n32(l['data_percent']), l['lv_attr'], l['lv_tags'])
 
         rc.append(lv)
     return rc

--- a/utils.py
+++ b/utils.py
@@ -35,14 +35,37 @@ def is_numeric(s):
     except ValueError:
         return False
 
+def rtype(rtype):
+    """Decorator making sure that the decorated function returns a value of
+    specified type.
+
+    """
+
+    def decorator(fn):
+        def decorated(*args, **kwargs):
+            return rtype(fn(*args, **kwargs))
+
+        return decorated
+
+    return decorator
+
 
 # Field is expected to be a number, handle the corner cases when parsing
+@rtype(dbus.UInt64)
 def n(v):
     if not v:
         return 0L
     if v.endswith('B'):
         return long(v[:-1])
     return long(float(v))
+
+@rtype(dbus.UInt32)
+def n32(v):
+    if not v:
+        return 0
+    if v.endswith('B'):
+        return int(v[:-1])
+    return int(float(v))
 
 
 # noinspection PyProtectedMember


### PR DESCRIPTION
Python doesn't have unsigned integer types and using long() instances results in
numbers being "exported" as Int64 no matter what the introspection data says and
clients thus get unexpected types not matching the introspection data.

Also change the type of 'data_percent' to UInt32 as it will never be negative
and bigger than 100.
