### PR TITLE
Do not prepend "--" to extra options specified as options

### DIFF
--- a/lvmdbus/cmdhandler.py
+++ b/lvmdbus/cmdhandler.py
@@ -158,7 +158,10 @@ def parse_column_names(out, column_names):
 def options_to_cli_args(options):
     rc = []
     for k, v in dict(options).items():
-        rc.append("--%s" % k)
+        if k.startswith("-"):
+            rc.append(k)
+        else:
+            rc.append("--%s" % k)
         rc.append(str(v))
     return rc
 


### PR DESCRIPTION
If the user code specifies e.g. "-f" (instead --force), it shouldn't be turned
into "---f". This makes the transition from CLI to DBus API easier for the user
code.
