### PR TITLE
Move the 'tmo' parameter of Snapshot() to where other methods have it

### DIFF
--- a/api.md
+++ b/api.md
@@ -41,8 +41,8 @@
 * Snapshot 
   * Arguments
       * name (String)
-      * tmo (int32_t)
       * optional_size (uint64_t)
+      * tmo (int32_t)
       * snapshot_options (Dictionary:{String, Variant})
   * Returns
       * Structure (Oject path, Oject path)

--- a/lvmdbus/lv.py
+++ b/lvmdbus/lv.py
@@ -299,10 +299,10 @@ def lv_object_factory(interface_name, *args):
             return '/'
 
         @dbus.service.method(dbus_interface=interface_name,
-                             in_signature='sita{sv}',
+                             in_signature='stia{sv}',
                              out_signature='(oo)',
                              async_callbacks=('cb', 'cbe'))
-        def Snapshot(self, name, tmo, optional_size, snapshot_options,
+        def Snapshot(self, name, optional_size, tmo, snapshot_options,
                      cb, cbe):
             r = RequestEntry(tmo, Lv._snap_shot,
                              (self.Uuid, self.lvm_id, name,


### PR DESCRIPTION
Other methods have the 'tmo' parameter as the last parameter before the
dictionary of extra parameters. That makes its use easy and simple. Having it on
a different position in this single method is inconsistent and complicates
things for the user code.
