### PR TITLE
Do not add empty values when adding extra options

### DIFF
--- a/lvmdbus/cmdhandler.py
+++ b/lvmdbus/cmdhandler.py
@@ -162,7 +162,8 @@ def options_to_cli_args(options):
             rc.append(k)
         else:
             rc.append("--%s" % k)
-        rc.append(str(v))
+        if v != "":
+            rc.append(str(v))
     return rc
 
 


### PR DESCRIPTION
If just an option is specified (e.g. '-K' to ignore the skip-on-activation flag)
and the value is "", the empty value should be just ignored because otherwise
there are two spaces in the command which confuses the wonderful (sarcasm)
custom-made option parsing the 'lvm' command uses.
