### PR TITLE
Add properties for lv_attr

### DIFF
--- a/lvmdbus/lv.py
+++ b/lvmdbus/lv.py
@@ -167,6 +167,7 @@ class LvCommon(AutomatedProperties):
     _IsThinPool_meta = ("b", LV_COMMON_INTERFACE)
     _Active_meta = ("b", LV_COMMON_INTERFACE)
     _VolumeType_meta = ("(ss)", LV_COMMON_INTERFACE)
+    _Permissions_meta = ("(ss)", LV_COMMON_INTERFACE)
 
     # noinspection PyUnusedLocal,PyPep8Naming
     def __init__(self, object_path, object_state):
@@ -188,6 +189,13 @@ class LvCommon(AutomatedProperties):
                     'e': 'raid or pool metadata or pool metadata spare',
                     '-': 'Unspecified'}
         return (self.state.Attr[0], type_map[self.state.Attr[0]])
+
+    @property
+    def Permissions(self):
+        type_map = {'w': 'writable', 'r': 'read-only',
+                    'R': 'Read-only activation of non-read-only volume',
+                    '-': 'Unspecified'}
+        return (self.state.Attr[1], type_map[self.state.Attr[1]])
 
     def signal_vg_pv_changes(self):
         # Signal property changes...

--- a/lvmdbus/lv.py
+++ b/lvmdbus/lv.py
@@ -172,6 +172,9 @@ class LvCommon(AutomatedProperties):
     _State_meta = ("(ss)", LV_COMMON_INTERFACE)
     _TargetType_meta = ("(ss)", LV_COMMON_INTERFACE)
     _Health_meta = ("(ss)", LV_COMMON_INTERFACE)
+    _FixedMinor_meta = ('b', LV_COMMON_INTERFACE)
+    _ZeroBlocks_meta = ('b', LV_COMMON_INTERFACE)
+    _SkipActivation = ('b', LV_COMMON_INTERFACE)
 
     # noinspection PyUnusedLocal,PyPep8Naming
     def __init__(self, object_path, object_state):
@@ -211,6 +214,10 @@ class LvCommon(AutomatedProperties):
         return (self.state.Attr[2], type_map[self.state.Attr[2]])
 
     @property
+    def FixedMinor(self):
+        return self.state.Attr[3] == 'm'
+
+    @property
     def State(self):
         type_map = {'a': 'active', 's': 'suspended', 'I': 'Invalid snapshot',
                     'S': 'invalid Suspended snapshot',
@@ -229,11 +236,19 @@ class LvCommon(AutomatedProperties):
         return (self.state.Attr[6], type_map[self.state.Attr[6]])
 
     @property
+    def ZeroBlocks(self):
+        return self.state.Attr[7] == 'z'
+
+    @property
     def Health(self):
         type_map = {'p': 'partial', 'r': 'refresh',
                     'm': 'mismatches', 'w': 'writemostly',
                     'X': 'X unknown', '-': 'Unspecified'}
         return (self.state.Attr[8], type_map[self.state.Attr[8]])
+
+    @property
+    def SkipActivation(self):
+        return self.state.Attr[9] == 'k'
 
     def signal_vg_pv_changes(self):
         # Signal property changes...

--- a/lvmdbus/lv.py
+++ b/lvmdbus/lv.py
@@ -168,6 +168,7 @@ class LvCommon(AutomatedProperties):
     _Active_meta = ("b", LV_COMMON_INTERFACE)
     _VolumeType_meta = ("(ss)", LV_COMMON_INTERFACE)
     _Permissions_meta = ("(ss)", LV_COMMON_INTERFACE)
+    _AllocationPolicy_meta = ("(ss)", LV_COMMON_INTERFACE)
 
     # noinspection PyUnusedLocal,PyPep8Naming
     def __init__(self, object_path, object_state):
@@ -196,6 +197,15 @@ class LvCommon(AutomatedProperties):
                     'R': 'Read-only activation of non-read-only volume',
                     '-': 'Unspecified'}
         return (self.state.Attr[1], type_map[self.state.Attr[1]])
+
+    @property
+    def AllocationPolicy(self):
+        type_map = {'a': 'anywhere', 'A': 'anywhere locked',
+                    'c': 'contiguous', 'C': 'contiguous locked',
+                    'i': 'inherited', 'I': 'inherited locked',
+                    'l': 'cling', 'L': 'cling locked',
+                    'n': 'normal', 'N': 'normal locked', '-': 'Unspecified'}
+        return (self.state.Attr[2], type_map[self.state.Attr[2]])
 
     def signal_vg_pv_changes(self):
         # Signal property changes...

--- a/lvmdbus/lv.py
+++ b/lvmdbus/lv.py
@@ -170,6 +170,7 @@ class LvCommon(AutomatedProperties):
     _Permissions_meta = ("(ss)", LV_COMMON_INTERFACE)
     _AllocationPolicy_meta = ("(ss)", LV_COMMON_INTERFACE)
     _State_meta = ("(ss)", LV_COMMON_INTERFACE)
+    _TargetType_meta = ("(ss)", LV_COMMON_INTERFACE)
 
     # noinspection PyUnusedLocal,PyPep8Naming
     def __init__(self, object_path, object_state):
@@ -218,6 +219,13 @@ class LvCommon(AutomatedProperties):
                     'i': 'mapped device present with inactive table',
                     'X': 'unknown', '-': 'Unspecified'}
         return (self.state.Attr[4], type_map[self.state.Attr[4]])
+
+    @property
+    def TargetType(self):
+        type_map = {'C': 'Cache', 'm': 'mirror', 'r': 'raid',
+                    's': 'snapshot', 't': 'thin', 'u': 'unknown',
+                    'v': 'virtual', '-': 'Unspecified'}
+        return (self.state.Attr[6], type_map[self.state.Attr[6]])
 
     def signal_vg_pv_changes(self):
         # Signal property changes...

--- a/lvmdbus/lv.py
+++ b/lvmdbus/lv.py
@@ -169,6 +169,7 @@ class LvCommon(AutomatedProperties):
     _VolumeType_meta = ("(ss)", LV_COMMON_INTERFACE)
     _Permissions_meta = ("(ss)", LV_COMMON_INTERFACE)
     _AllocationPolicy_meta = ("(ss)", LV_COMMON_INTERFACE)
+    _State_meta = ("(ss)", LV_COMMON_INTERFACE)
 
     # noinspection PyUnusedLocal,PyPep8Naming
     def __init__(self, object_path, object_state):
@@ -206,6 +207,17 @@ class LvCommon(AutomatedProperties):
                     'l': 'cling', 'L': 'cling locked',
                     'n': 'normal', 'N': 'normal locked', '-': 'Unspecified'}
         return (self.state.Attr[2], type_map[self.state.Attr[2]])
+
+    @property
+    def State(self):
+        type_map = {'a': 'active', 's': 'suspended', 'I': 'Invalid snapshot',
+                    'S': 'invalid Suspended snapshot',
+                    'm': 'snapshot merge failed',
+                    'M': 'suspended snapshot (M)erge failed',
+                    'd': 'mapped device present without  tables',
+                    'i': 'mapped device present with inactive table',
+                    'X': 'unknown', '-': 'Unspecified'}
+        return (self.state.Attr[4], type_map[self.state.Attr[4]])
 
     def signal_vg_pv_changes(self):
         # Signal property changes...

--- a/lvmdbus/lv.py
+++ b/lvmdbus/lv.py
@@ -166,12 +166,28 @@ class LvCommon(AutomatedProperties):
     _IsThinVolume_meta = ("b", LV_COMMON_INTERFACE)
     _IsThinPool_meta = ("b", LV_COMMON_INTERFACE)
     _Active_meta = ("b", LV_COMMON_INTERFACE)
+    _VolumeType_meta = ("(ss)", LV_COMMON_INTERFACE)
 
     # noinspection PyUnusedLocal,PyPep8Naming
     def __init__(self, object_path, object_state):
         super(LvCommon, self).__init__(object_path, lvs_state_retrieve)
         self.set_interface(LV_COMMON_INTERFACE)
         self.state = object_state
+
+    @property
+    def VolumeType(self):
+        type_map = {'C': 'Cache', 'm': 'mirrored',
+                    'M': 'Mirrored without initial sync', 'o': 'origin',
+                    'O': 'Origin with merging snapshot', 'r': 'raid',
+                    'R': 'Raid without initial sync', 's': 'snapshot',
+                    'S': 'merging Snapshot', 'p': 'pvmove',
+                    'v': 'virtual', 'i': 'mirror  or  raid  image',
+                    'I': 'mirror or raid Image out-of-sync',
+                    'l': 'mirror log device', 'c': 'under conversion',
+                    'V': 'thin Volume', 't': 'thin pool', 'T': 'Thin pool data',
+                    'e': 'raid or pool metadata or pool metadata spare',
+                    '-': 'Unspecified'}
+        return (self.state.Attr[0], type_map[self.state.Attr[0]])
 
     def signal_vg_pv_changes(self):
         # Signal property changes...

--- a/lvmdbus/lv.py
+++ b/lvmdbus/lv.py
@@ -171,6 +171,7 @@ class LvCommon(AutomatedProperties):
     _AllocationPolicy_meta = ("(ss)", LV_COMMON_INTERFACE)
     _State_meta = ("(ss)", LV_COMMON_INTERFACE)
     _TargetType_meta = ("(ss)", LV_COMMON_INTERFACE)
+    _Health_meta = ("(ss)", LV_COMMON_INTERFACE)
 
     # noinspection PyUnusedLocal,PyPep8Naming
     def __init__(self, object_path, object_state):
@@ -226,6 +227,13 @@ class LvCommon(AutomatedProperties):
                     's': 'snapshot', 't': 'thin', 'u': 'unknown',
                     'v': 'virtual', '-': 'Unspecified'}
         return (self.state.Attr[6], type_map[self.state.Attr[6]])
+
+    @property
+    def Health(self):
+        type_map = {'p': 'partial', 'r': 'refresh',
+                    'm': 'mismatches', 'w': 'writemostly',
+                    'X': 'X unknown', '-': 'Unspecified'}
+        return (self.state.Attr[8], type_map[self.state.Attr[8]])
 
     def signal_vg_pv_changes(self):
         # Signal property changes...


### PR DESCRIPTION
@vpodzime Please take a look and see what you think.  I've done what you suggested, expect that the order is reversed on (ss).  I thought most programs using the API will utilize the single character instead of the string representation, so made it first.  Additionally the string representation is a little verbose, but I think this could be beneficial for application writes who want to convey the information to end users.

I've left out the `open` as that can be a rapidly changing causing spurious properties changed signals.  Need to modify the code so we can selectively ignore properties when diffing them.
